### PR TITLE
 added logic to abort applying the scPlayer() if the source element has already had an scPlayer assigned

### DIFF
--- a/js/sc-player.js
+++ b/js/sc-player.js
@@ -490,6 +490,11 @@
         $info = $('<div class="sc-info"><h3></h3><h4></h4><p></p><a href="#" class="sc-info-close">X</a></div>').appendTo($player),
         $controls = $('<div class="sc-controls"></div>').appendTo($player),
         $list = $('<ol class="sc-trackslist"></ol>').appendTo($player);
+        
+        // Don't initialise already initialised sc-player element
+        if(typeof $source.data('sc-player') === 'object'){
+          return;
+        }
 
         // add the classes of the source node to the player itself
         // the players can be indvidually styled this way


### PR DESCRIPTION
I found through some dodgy JS code of my own that multiple calls of `scPlayer()` on a source element weren't being aborted if the `scPlayer()` functionality was already applied. This resulted in the internal links of the generated `scPlayer()` element (such as `#play`, `#pause`, `#info`, etc.) to then try to be referenced as `scApiUrl()`s which then resulted in errors and no media being loaded.

I think ideally all the var setting logic which involves DOM-crawling would follow the abort code so as to lower any further unnecessary overheads.
