### PR TITLE
Improving compatibility with jQuery 1.9+

### DIFF
--- a/js/sc-player.js
+++ b/js/sc-player.js
@@ -171,7 +171,7 @@
           player,
           flashHtml = function(url) {
             var swf = (secureDocument ? 'https' : 'http') + '://player.' + domain +'/player.swf?url=' + url +'&amp;enable_api=true&amp;player_type=engine&amp;object_id=' + engineId;
-            if ($.browser.msie) {
+            if ($.browser && $.browser.msie) {
               return '<object height="100%" width="100%" id="' + engineId + '" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" data="' + swf + '">'+
                 '<param name="movie" value="' + swf + '" />'+
                 '<param name="allowscriptaccess" value="always" />'+

--- a/js/sc-player.js
+++ b/js/sc-player.js
@@ -169,9 +169,14 @@
     var flashDriver = function() {
       var engineId = 'scPlayerEngine',
           player,
+          lessThanEqualToIE9 = (function(){ // Detects IE9 and lower
+            var div = document.createElement('div');
+            div.innerHTML = '<!--[if IE]><i></i><![endif]-->';
+            return div.getElementsByTagName('i').length > 0;
+          }()),
           flashHtml = function(url) {
             var swf = (secureDocument ? 'https' : 'http') + '://player.' + domain +'/player.swf?url=' + url +'&amp;enable_api=true&amp;player_type=engine&amp;object_id=' + engineId;
-            if ($.browser && $.browser.msie) {
+            if (lessThanEqualToIE9) {
               return '<object height="100%" width="100%" id="' + engineId + '" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" data="' + swf + '">'+
                 '<param name="movie" value="' + swf + '" />'+
                 '<param name="allowscriptaccess" value="always" />'+

--- a/js/sc-player.js
+++ b/js/sc-player.js
@@ -169,7 +169,7 @@
     var flashDriver = function() {
       var engineId = 'scPlayerEngine',
           player,
-          lessThanEqualToIE9 = (function(){ // Detects IE9 and lower
+          lessThanEqualToIE9 = (function(){
             var div = document.createElement('div');
             div.innerHTML = '<!--[if IE]><i></i><![endif]-->';
             return div.getElementsByTagName('i').length > 0;


### PR DESCRIPTION
Small fix to remove a nested lookup which assumes access to a part of jQuery's API that has been removed as of 1.9.

Reference: http://api.jquery.com/jQuery.browser/