### PR TITLE
Fix Seek Scrub While Paused

### DIFF
--- a/js/sc-player.js
+++ b/js/sc-player.js
@@ -396,6 +396,7 @@
       onSeek = function(player, relative) {
         audioEngine.seek(relative);
         $(player).trigger('onPlayerSeek');
+        updatePlayStatus(player, true);
       },
       onSkip = function(player) {
         var $player = $(player);


### PR DESCRIPTION
When file is loaded but paused, seek will start playing the audio, but will not update the player to "playing" mode. If this point in the code is reached, we can assume the audio has began playing, so it should be safe to update the play status.
